### PR TITLE
build autobahn w/ static linked stdlib on release

### DIFF
--- a/Autobahn.swift
+++ b/Autobahn.swift
@@ -18,7 +18,7 @@ Autobahn(Highway.self)
 
 .highway(.buildRelease) {
 	print("Building...")
-	try sh("swift", "build", "-c", "release")
+	try sh("swift", "build", "-c", "release", "--static-swift-stdlib")
 }
 
 .highway(.test) {


### PR DESCRIPTION
Afaict this is/will be used to build releases for Autobahn. In that case it really helps to link Swift's stdlib statically since people will have different toolchains running on their devices and the small speed improvement is also nice to have 😊 